### PR TITLE
wrapLabel: check for case when value is set without an attribute.

### DIFF
--- a/src/float-labels.js
+++ b/src/float-labels.js
@@ -324,12 +324,11 @@
 
 		/** @return void */
 		wrapLabel: function( labelEl, el )
-		{
-			var hasValWithoutAttr = !el.hasAttribute( 'value' ) && el.value !== undefined && el.value.length;
+		{			
 			var wrapper = this.createEl( 'div', {
 				class: this.prefixed( 'wrap' ) + ' ' + this.prefixed( 'wrap-' + el.tagName.toLowerCase() ),
 			});
-			if( ( el.hasAttribute( 'value' ) && el.value.length ) || hasValWithoutAttr ) {
+			if( el.value !== undefined && el.value.length ) {
 				wrapper.classList.add( this.prefixed( 'is-active' ));
 			}
 			if( el.getAttribute( 'required' ) !== null || el.classList.contains( this.config[this.current].requiredClass )) {

--- a/src/float-labels.js
+++ b/src/float-labels.js
@@ -325,10 +325,11 @@
 		/** @return void */
 		wrapLabel: function( labelEl, el )
 		{
+			var hasValWithoutAttr = !el.hasAttribute( 'value' ) && el.value !== undefined && el.value.length;
 			var wrapper = this.createEl( 'div', {
 				class: this.prefixed( 'wrap' ) + ' ' + this.prefixed( 'wrap-' + el.tagName.toLowerCase() ),
 			});
-			if( el.hasAttribute( 'value' ) && el.value.length ) {
+			if( ( el.hasAttribute( 'value' ) && el.value.length ) || hasValWithoutAttr ) {
 				wrapper.classList.add( this.prefixed( 'is-active' ));
 			}
 			if( el.getAttribute( 'required' ) !== null || el.classList.contains( this.config[this.current].requiredClass )) {

--- a/src/float-labels.js
+++ b/src/float-labels.js
@@ -324,7 +324,7 @@
 
 		/** @return void */
 		wrapLabel: function( labelEl, el )
-		{			
+		{
 			var wrapper = this.createEl( 'div', {
 				class: this.prefixed( 'wrap' ) + ' ' + this.prefixed( 'wrap-' + el.tagName.toLowerCase() ),
 			});


### PR DESCRIPTION
This handles a scenario when using certain frameworks that handle data-binding outside of the `value` attribute.  For example in Angular an input will look something like

Small change will check in 'wrapLabel' method to see if the element has a value even if a value attribute is not present. 

`<input id="firstName" type="text" [(ngModel)]="person.firstName">`